### PR TITLE
fix: add missing granularity field to STODesign

### DIFF
--- a/sto/sto_design.go
+++ b/sto/sto_design.go
@@ -12,15 +12,17 @@ var (
 
 type STODesign struct {
 	hint.BaseHinter
-	stoID  extensioncurrency.ContractID
-	policy STOPolicy
+	stoID       extensioncurrency.ContractID
+	granularity uint64
+	policy      STOPolicy
 }
 
-func NewSTODesign(stoID extensioncurrency.ContractID, policy STOPolicy) STODesign {
+func NewSTODesign(stoID extensioncurrency.ContractID, granularity uint64, policy STOPolicy) STODesign {
 	return STODesign{
-		BaseHinter: hint.NewBaseHinter(STODesignHint),
-		stoID:      stoID,
-		policy:     policy,
+		BaseHinter:  hint.NewBaseHinter(STODesignHint),
+		stoID:       stoID,
+		granularity: granularity,
+		policy:      policy,
 	}
 }
 
@@ -43,12 +45,17 @@ func (s STODesign) IsValid([]byte) error {
 func (s STODesign) Bytes() []byte {
 	return util.ConcatBytesSlice(
 		s.stoID.Bytes(),
+		util.Uint64ToBigBytes(s.granularity),
 		s.policy.Bytes(),
 	)
 }
 
 func (s STODesign) STO() extensioncurrency.ContractID {
 	return s.stoID
+}
+
+func (s STODesign) Granularity() uint64 {
+	return s.granularity
 }
 
 func (s STODesign) Policy() STOPolicy {

--- a/sto/sto_design_bson.go
+++ b/sto/sto_design_bson.go
@@ -11,17 +11,19 @@ import (
 func (de STODesign) MarshalBSON() ([]byte, error) {
 	return bsonenc.Marshal(
 		bson.M{
-			"_hint":  de.Hint().String(),
-			"stoid":  de.stoID,
-			"policy": de.policy,
+			"_hint":       de.Hint().String(),
+			"stoid":       de.stoID,
+			"granularity": de.granularity,
+			"policy":      de.policy,
 		},
 	)
 }
 
 type STODesignBSONUnmarshaler struct {
-	Hint   string   `bson:"_hint"`
-	STO    string   `bson:"stoid"`
-	Policy bson.Raw `bson:"policy"`
+	Hint        string   `bson:"_hint"`
+	STO         string   `bson:"stoid"`
+	Granularity uint64   `bson:"granularity"`
+	Policy      bson.Raw `bson:"policy"`
 }
 
 func (de *STODesign) DecodeBSON(b []byte, enc *bsonenc.Encoder) error {
@@ -37,5 +39,5 @@ func (de *STODesign) DecodeBSON(b []byte, enc *bsonenc.Encoder) error {
 		return e(err, "")
 	}
 
-	return de.unpack(enc, ht, ud.STO, ud.Policy)
+	return de.unpack(enc, ht, ud.STO, ud.Granularity, ud.Policy)
 }

--- a/sto/sto_design_encode.go
+++ b/sto/sto_design_encode.go
@@ -7,11 +7,12 @@ import (
 	"github.com/ProtoconNet/mitum2/util/hint"
 )
 
-func (de *STODesign) unpack(enc encoder.Encoder, ht hint.Hint, sto string, bpo []byte) error {
+func (de *STODesign) unpack(enc encoder.Encoder, ht hint.Hint, sto string, gra uint64, bpo []byte) error {
 	e := util.StringErrorFunc("failed to decode bson of STODesign")
 
 	de.BaseHinter = hint.NewBaseHinter(ht)
 	de.stoID = extensioncurrency.ContractID(sto)
+	de.granularity = gra
 
 	if hinter, err := enc.Decode(bpo); err != nil {
 		return e(err, "")

--- a/sto/sto_design_json.go
+++ b/sto/sto_design_json.go
@@ -11,22 +11,25 @@ import (
 
 type STODesignJSONMarshaler struct {
 	hint.BaseHinter
-	STO    extensioncurrency.ContractID `json:"stoid"`
-	Policy STOPolicy                    `json:"policy"`
+	STO         extensioncurrency.ContractID `json:"stoid"`
+	Granularity uint64                       `json:"granularity"`
+	Policy      STOPolicy                    `json:"policy"`
 }
 
 func (de STODesign) MarshalJSON() ([]byte, error) {
 	return util.MarshalJSON(STODesignJSONMarshaler{
-		BaseHinter: de.BaseHinter,
-		STO:        de.stoID,
-		Policy:     de.policy,
+		BaseHinter:  de.BaseHinter,
+		STO:         de.stoID,
+		Granularity: de.granularity,
+		Policy:      de.policy,
 	})
 }
 
 type STODesignJSONUnmarshaler struct {
-	Hint   hint.Hint       `json:"_hint"`
-	STO    string          `json:"stoid"`
-	Policy json.RawMessage `json:"policy"`
+	Hint        hint.Hint       `json:"_hint"`
+	STO         string          `json:"stoid"`
+	Granularity uint64          `json:"granularity"`
+	Policy      json.RawMessage `json:"policy"`
 }
 
 func (de *STODesign) DecodeJSON(b []byte, enc *jsonenc.Encoder) error {
@@ -37,5 +40,5 @@ func (de *STODesign) DecodeJSON(b []byte, enc *jsonenc.Encoder) error {
 		return e(err, "")
 	}
 
-	return de.unpack(enc, ud.Hint, ud.STO, ud.Policy)
+	return de.unpack(enc, ud.Hint, ud.STO, ud.Granularity, ud.Policy)
 }


### PR DESCRIPTION
### Pull-request Type (fix, feat, bug, doc, chore, test, etc...) 
- fix
### Current Behavior (Link to an open issue)
- Close #26 
### New Behavior (if this is a feature change)
- The granularity field is present in the STODesign struct.