### PR TITLE
fix: Add missing field to AuthorizeOperatorsItem

### DIFF
--- a/sto/authorize_operators_item.go
+++ b/sto/authorize_operators_item.go
@@ -12,18 +12,20 @@ var AuthorizeOperatorsItemHint = hint.MustNewHint("mitum-sto-authorize-operators
 
 type AuthorizeOperatorsItem struct {
 	hint.BaseHinter
-	stoID    extensioncurrency.ContractID // token id
-	contract base.Address
-	operator base.Address        // initial controllers
-	currency currency.CurrencyID // fee
+	stoID     extensioncurrency.ContractID // token id
+	contract  base.Address                 // contract address
+	operator  base.Address                 // initial controllers
+	partition Partition                    // partition
+	currency  currency.CurrencyID          // fee
 }
 
-func NewAuthorizeOperatorsItem(stoID extensioncurrency.ContractID, contract, operator base.Address, currency currency.CurrencyID) AuthorizeOperatorsItem {
+func NewAuthorizeOperatorsItem(stoID extensioncurrency.ContractID, contract, operator base.Address, partition Partition, currency currency.CurrencyID) AuthorizeOperatorsItem {
 	return AuthorizeOperatorsItem{
 		BaseHinter: hint.NewBaseHinter(AuthorizeOperatorsItemHint),
 		stoID:      stoID,
 		contract:   contract,
 		operator:   operator,
+		partition:  partition,
 		currency:   currency,
 	}
 }
@@ -33,12 +35,13 @@ func (it AuthorizeOperatorsItem) Bytes() []byte {
 		it.stoID.Bytes(),
 		it.contract.Bytes(),
 		it.operator.Bytes(),
+		it.partition.Bytes(),
 		it.currency.Bytes(),
 	)
 }
 
 func (it AuthorizeOperatorsItem) IsValid([]byte) error {
-	if err := util.CheckIsValiders(nil, false, it.BaseHinter, it.stoID, it.contract, it.operator, it.currency); err != nil {
+	if err := util.CheckIsValiders(nil, false, it.BaseHinter, it.stoID, it.contract, it.operator, it.partition, it.currency); err != nil {
 		return err
 	}
 
@@ -59,6 +62,10 @@ func (it AuthorizeOperatorsItem) Contract() base.Address {
 
 func (it AuthorizeOperatorsItem) Operator() base.Address {
 	return it.operator
+}
+
+func (it AuthorizeOperatorsItem) Partition() Partition {
+	return it.partition
 }
 
 func (it AuthorizeOperatorsItem) Currency() currency.CurrencyID {

--- a/sto/authorize_operators_item_bson.go
+++ b/sto/authorize_operators_item_bson.go
@@ -10,21 +10,23 @@ import (
 func (it AuthorizeOperatorsItem) MarshalBSON() ([]byte, error) {
 	return bsonenc.Marshal(
 		bson.M{
-			"_hint":    it.Hint().String(),
-			"stoid":    it.stoID,
-			"contract": it.contract,
-			"operator": it.operator,
-			"currency": it.currency,
+			"_hint":     it.Hint().String(),
+			"stoid":     it.stoID,
+			"contract":  it.contract,
+			"operator":  it.operator,
+			"partition": it.partition,
+			"currency":  it.currency,
 		},
 	)
 }
 
 type AuthorizeOperatorsItemBSONUnmarshaler struct {
-	Hint     string `bson:"_hint"`
-	STO      string `bson:"stoid"`
-	Contract string `bson:"contract"`
-	Operator string `bson:"operator"`
-	Currency string `bson:"currency"`
+	Hint      string `bson:"_hint"`
+	STO       string `bson:"stoid"`
+	Contract  string `bson:"contract"`
+	Operator  string `bson:"operator"`
+	Partition string `bson:"partition"`
+	Currency  string `bson:"currency"`
 }
 
 func (it *AuthorizeOperatorsItem) DecodeBSON(b []byte, enc *bsonenc.Encoder) error {
@@ -40,5 +42,5 @@ func (it *AuthorizeOperatorsItem) DecodeBSON(b []byte, enc *bsonenc.Encoder) err
 		return e(err, "")
 	}
 
-	return it.unpack(enc, ht, uit.STO, uit.Contract, uit.Operator, uit.Currency)
+	return it.unpack(enc, ht, uit.STO, uit.Contract, uit.Operator, uit.Partition, uit.Currency)
 }

--- a/sto/authorize_operators_item_encode.go
+++ b/sto/authorize_operators_item_encode.go
@@ -9,11 +9,12 @@ import (
 	"github.com/ProtoconNet/mitum2/util/hint"
 )
 
-func (it *AuthorizeOperatorsItem) unpack(enc encoder.Encoder, ht hint.Hint, sto, ca, op, cid string) error {
+func (it *AuthorizeOperatorsItem) unpack(enc encoder.Encoder, ht hint.Hint, sto, ca, op, pt, cid string) error {
 	e := util.StringErrorFunc("failed to unmarshal AuthorizeOperatorsItem")
 
 	it.BaseHinter = hint.NewBaseHinter(ht)
 	it.stoID = extensioncurrency.ContractID(sto)
+	it.partition = Partition(pt)
 	it.currency = currency.CurrencyID(cid)
 
 	switch a, err := base.DecodeAddress(ca, enc); {

--- a/sto/authorize_operators_item_json.go
+++ b/sto/authorize_operators_item_json.go
@@ -11,10 +11,11 @@ import (
 
 type AuthorizeOperatorsItemJSONMarshaler struct {
 	hint.BaseHinter
-	STO      extensioncurrency.ContractID `json:"stoid"`
-	Contract base.Address                 `json:"contract"`
-	Operator base.Address                 `json:"operator"`
-	Currency currency.CurrencyID          `json:"currency"`
+	STO       extensioncurrency.ContractID `json:"stoid"`
+	Contract  base.Address                 `json:"contract"`
+	Operator  base.Address                 `json:"operator"`
+	Partition Partition                    `json:"partition"`
+	Currency  currency.CurrencyID          `json:"currency"`
 }
 
 func (it AuthorizeOperatorsItem) MarshalJSON() ([]byte, error) {
@@ -23,16 +24,18 @@ func (it AuthorizeOperatorsItem) MarshalJSON() ([]byte, error) {
 		STO:        it.stoID,
 		Contract:   it.contract,
 		Operator:   it.operator,
+		Partition:  it.partition,
 		Currency:   it.currency,
 	})
 }
 
 type AuthorizeOperatorsItemJSONUnMarshaler struct {
-	Hint     hint.Hint `json:"_hint"`
-	STO      string    `json:"stoid"`
-	Contract string    `json:"contract"`
-	Operator string    `json:"operator"`
-	Currency string    `json:"currency"`
+	Hint      hint.Hint `json:"_hint"`
+	STO       string    `json:"stoid"`
+	Contract  string    `json:"contract"`
+	Operator  string    `json:"operator"`
+	Partition string    `json:"partition"`
+	Currency  string    `json:"currency"`
 }
 
 func (it *AuthorizeOperatorsItem) DecodeJSON(b []byte, enc *jsonenc.Encoder) error {
@@ -43,5 +46,5 @@ func (it *AuthorizeOperatorsItem) DecodeJSON(b []byte, enc *jsonenc.Encoder) err
 		return e(err, "")
 	}
 
-	return it.unpack(enc, uit.Hint, uit.STO, uit.Contract, uit.Operator, uit.Currency)
+	return it.unpack(enc, uit.Hint, uit.STO, uit.Contract, uit.Operator, uit.Partition, uit.Currency)
 }


### PR DESCRIPTION
### Pull-request Type (fix, feat, bug, doc, chore, test, etc...) 
- fix
### Current Behavior (Link to an open issue)
- close #32 
### New Behavior (if this is a feature change)
- The partition field is present in AuthorizeOperatorsItem struct.