### PR TITLE
fix: use partition to generate operator tokenholders state key

### DIFF
--- a/sto/authorize_operators_process.go
+++ b/sto/authorize_operators_process.go
@@ -84,7 +84,7 @@ func (ipp *AuthorizeOperatorsItemProcessor) Process(
 	holders := append(*ipp.tokenHolders, ipp.sender)
 
 	sts[0] = NewStateMergeValue(
-		StateKeyOperatorTokenHolders(it.Contract(), it.STO(), it.Operator()),
+		StateKeyOperatorTokenHolders(it.Contract(), it.STO(), it.Operator(), it.Partition()),
 		NewOperatorTokenHoldersStateValue(holders),
 	)
 
@@ -182,7 +182,7 @@ func (opp *AuthorizeOperatorsProcessor) PreProcess(
 			operators[k] = &ops
 		}
 
-		k = StateKeyOperatorTokenHolders(it.Contract(), it.STO(), it.Operator())
+		k = StateKeyOperatorTokenHolders(it.Contract(), it.STO(), it.Operator(), it.Partition())
 		if _, found := holders[k]; !found {
 			switch st, found, err := getStateFunc(k); {
 			case err != nil:
@@ -211,7 +211,7 @@ func (opp *AuthorizeOperatorsProcessor) PreProcess(
 		ipc.sender = fact.Sender()
 		ipc.item = it
 		ipc.operators = operators[StateKeyTokenHolderPartitionOperators(it.Contract(), it.STO(), fact.sender, it.Partition())]
-		ipc.tokenHolders = holders[StateKeyOperatorTokenHolders(it.Contract(), it.STO(), it.Operator())]
+		ipc.tokenHolders = holders[StateKeyOperatorTokenHolders(it.Contract(), it.STO(), it.Operator(), it.Partition())]
 
 		if err := ipc.PreProcess(ctx, op, getStateFunc); err != nil {
 			return nil, base.NewBaseOperationProcessReasonError("fail to preprocess AuthorizeOperatorsItem: %w", err), nil
@@ -258,7 +258,7 @@ func (opp *AuthorizeOperatorsProcessor) Process( // nolint:dupl
 			operators[k] = &ops
 		}
 
-		k = StateKeyOperatorTokenHolders(it.Contract(), it.STO(), it.Operator())
+		k = StateKeyOperatorTokenHolders(it.Contract(), it.STO(), it.Operator(), it.Partition())
 		if _, found := holders[k]; !found {
 			switch st, found, err := getStateFunc(k); {
 			case err != nil:
@@ -288,7 +288,7 @@ func (opp *AuthorizeOperatorsProcessor) Process( // nolint:dupl
 		ipc.sender = fact.Sender()
 		ipc.item = it
 		ipc.operators = operators[StateKeyTokenHolderPartitionOperators(it.Contract(), it.STO(), fact.sender, it.Partition())]
-		ipc.tokenHolders = holders[StateKeyOperatorTokenHolders(it.Contract(), it.STO(), it.Operator())]
+		ipc.tokenHolders = holders[StateKeyOperatorTokenHolders(it.Contract(), it.STO(), it.Operator(), it.Partition())]
 
 		s, err := ipc.Process(ctx, op, getStateFunc)
 		if err != nil {

--- a/sto/revoke_operators_process.go
+++ b/sto/revoke_operators_process.go
@@ -118,7 +118,7 @@ func (ipp *RevokeOperatorsItemProcessor) Process(
 	}
 
 	sts[0] = NewStateMergeValue(
-		StateKeyOperatorTokenHolders(it.Contract(), it.STO(), it.Operator()),
+		StateKeyOperatorTokenHolders(it.Contract(), it.STO(), it.Operator(), it.Partition()),
 		NewOperatorTokenHoldersStateValue(holders),
 	)
 
@@ -216,7 +216,7 @@ func (opp *RevokeOperatorsProcessor) PreProcess(
 			operators[k] = &ops
 		}
 
-		k = StateKeyOperatorTokenHolders(it.Contract(), it.STO(), it.Operator())
+		k = StateKeyOperatorTokenHolders(it.Contract(), it.STO(), it.Operator(), it.Partition())
 		if _, found := holders[k]; !found {
 			switch st, found, err := getStateFunc(k); {
 			case err != nil:
@@ -244,7 +244,7 @@ func (opp *RevokeOperatorsProcessor) PreProcess(
 		ipc.sender = fact.Sender()
 		ipc.item = it
 		ipc.operators = operators[StateKeyTokenHolderPartitionOperators(it.Contract(), it.STO(), fact.sender, it.Partition())]
-		ipc.tokenHolders = holders[StateKeyOperatorTokenHolders(it.Contract(), it.STO(), it.Operator())]
+		ipc.tokenHolders = holders[StateKeyOperatorTokenHolders(it.Contract(), it.STO(), it.Operator(), it.Partition())]
 
 		if err := ipc.PreProcess(ctx, op, getStateFunc); err != nil {
 			return nil, base.NewBaseOperationProcessReasonError("fail to preprocess RevokeOperatorsItem: %w", err), nil
@@ -291,7 +291,7 @@ func (opp *RevokeOperatorsProcessor) Process( // nolint:dupl
 			operators[k] = &ops
 		}
 
-		k = StateKeyOperatorTokenHolders(it.Contract(), it.STO(), it.Operator())
+		k = StateKeyOperatorTokenHolders(it.Contract(), it.STO(), it.Operator(), it.Partition())
 		if _, found := holders[k]; !found {
 			switch st, found, err := getStateFunc(k); {
 			case err != nil:
@@ -321,7 +321,7 @@ func (opp *RevokeOperatorsProcessor) Process( // nolint:dupl
 		ipc.sender = fact.Sender()
 		ipc.item = it
 		ipc.operators = operators[StateKeyTokenHolderPartitionOperators(it.Contract(), it.STO(), fact.sender, it.Partition())]
-		ipc.tokenHolders = holders[StateKeyOperatorTokenHolders(it.Contract(), it.STO(), it.Operator())]
+		ipc.tokenHolders = holders[StateKeyOperatorTokenHolders(it.Contract(), it.STO(), it.Operator(), it.Partition())]
 
 		s, err := ipc.Process(ctx, op, getStateFunc)
 		if err != nil {

--- a/sto/state.go
+++ b/sto/state.go
@@ -511,8 +511,8 @@ func (o OperatorTokenHoldersStateValue) HashBytes() []byte {
 	return util.ConcatBytesSlice(bs...)
 }
 
-func StateKeyOperatorTokenHolders(caddr base.Address, stoID extensioncurrency.ContractID, oaddr base.Address) string {
-	return fmt.Sprintf("%s-%s%s", StateKeySTOPrefix(caddr, stoID), oaddr.String(), OperatorTokenHoldersSuffix)
+func StateKeyOperatorTokenHolders(caddr base.Address, stoID extensioncurrency.ContractID, oaddr base.Address, partition Partition) string {
+	return fmt.Sprintf("%s-%s-%s%s", StateKeySTOPrefix(caddr, stoID), oaddr.String(), partition.String(), OperatorTokenHoldersSuffix)
 }
 
 func IsStateOperatorTokenHoldersKey(key string) bool {


### PR DESCRIPTION
### Pull-request Type (fix, feat, bug, doc, chore, test, etc...) 

- fix bug

### Current Behavior (Link to an open issue)

- Close #40 

### New Behavior (if this is a feature change)

- add partition to operation tokenholders state key
