### PR TITLE
fix: wrong behavior of create-sto and revoke-operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*/**/.DS_Store
+mitum-data/**/*

--- a/cmds/hinters.go
+++ b/cmds/hinters.go
@@ -73,8 +73,8 @@ var hinters = []encoder.DecodeDetail{
 	{Hint: sto.RedeemTokensHint, Instance: sto.RedeemTokens{}},
 	{Hint: sto.AuthorizeOperatorsItemHint, Instance: sto.AuthorizeOperatorsItem{}},
 	{Hint: sto.AuthorizeOperatorsHint, Instance: sto.AuthorizeOperators{}},
-	{Hint: sto.RevokeOperatorsItemHint, Instance: sto.AuthorizeOperatorsItem{}},
-	{Hint: sto.RevokeOperatorsHint, Instance: sto.AuthorizeOperators{}},
+	{Hint: sto.RevokeOperatorsItemHint, Instance: sto.RevokeOperatorsItem{}},
+	{Hint: sto.RevokeOperatorsHint, Instance: sto.RevokeOperators{}},
 	{Hint: sto.SetDocumentHint, Instance: sto.SetDocument{}},
 
 	{Hint: digestisaac.ManifestHint, Instance: digestisaac.Manifest{}},

--- a/genesis-design.yml
+++ b/genesis-design.yml
@@ -3,7 +3,7 @@ facts:
     nodes:
       - _hint: currency-node-v0.0.1
         address: no0sas
-        publickey: cqau9ymXjiVVU5Q5Hk1niAt6H38756JSkXdyvMw9LhV9mpu
+        publickey: 27kpTQCEPhrMugHxPzAq174mgCZiSBP66rZsqjCHMYhLAmpu
 
   - _hint: currency-genesis-network-policy-fact-v0.0.1
     policy:
@@ -15,7 +15,7 @@ facts:
         limit: 1
       max_suffrage_size: 3
   - _hint: mitum-currency-genesis-currencies-operation-fact-v0.0.1
-    genesis_node_key: bXTT1hoetSKYPUmfu3bMRcs8aU342MTTzhgeCQ1bTavBmpu
+    genesis_node_key: 27kpTQCEPhrMugHxPzAq174mgCZiSBP66rZsqjCHMYhLAmpu
     keys:
       _hint: mitum-currency-keys-v0.0.1  
       keys: 

--- a/standalone.yml
+++ b/standalone.yml
@@ -1,5 +1,5 @@
 address: no0sas
-privatekey: EYc4WdFjP9qkgfwJZfnsVXeh827rsNppm5HUSjSDeMFFmpr
+privatekey: FjeFfxM7jQN9Geaww6XraGMvVfaxAn5DrVUp4FyRjc35mpr
 network_id: mitum
 network:
   bind: 0.0.0.0:4320
@@ -7,9 +7,3 @@ network:
 storage:
   base: ./mitum-data
   database: leveldb://
-# digest:
-#   network:
-#     bind: http://localhost:54320
-#     url: http://localhost:54320
-#   database: 
-#     uri: mongodb://127.0.0.1:27017/mc-sto

--- a/sto/authorize_operators_process.go
+++ b/sto/authorize_operators_process.go
@@ -153,7 +153,7 @@ func (opp *AuthorizeOperatorsProcessor) PreProcess(
 	}
 
 	if err := checkNotExistsState(extensioncurrency.StateKeyContractAccount(fact.Sender()), getStateFunc); err != nil {
-		return ctx, base.NewBaseOperationProcessReasonError("contract account cannot set its operators, %q", fact.Sender()), nil
+		return ctx, base.NewBaseOperationProcessReasonError("contract account cannot set its operators, %q: %w", fact.Sender(), err), nil
 	}
 
 	if err := checkFactSignsByState(fact.sender, op.Signs(), getStateFunc); err != nil {
@@ -170,11 +170,11 @@ func (opp *AuthorizeOperatorsProcessor) PreProcess(
 		if _, found := operators[k]; !found {
 			switch st, found, err := getStateFunc(k); {
 			case err != nil:
-				return nil, base.NewBaseOperationProcessReasonError("failed to find tokenholder partition operators, %s", k), nil
+				return nil, base.NewBaseOperationProcessReasonError("failed to find tokenholder partition operators, %s: %w", k, err), nil
 			case found:
 				ops, err = StateTokenHolderPartitionOperatorsValue(st)
 				if err != nil {
-					return nil, base.NewBaseOperationProcessReasonError("failed to get tokenholder partition operators, %s", k), nil
+					return nil, base.NewBaseOperationProcessReasonError("failed to get tokenholder partition operators, %s: %w", k, err), nil
 				}
 			default:
 				ops = []base.Address{}
@@ -186,11 +186,11 @@ func (opp *AuthorizeOperatorsProcessor) PreProcess(
 		if _, found := holders[k]; !found {
 			switch st, found, err := getStateFunc(k); {
 			case err != nil:
-				return nil, base.NewBaseOperationProcessReasonError("failed to find operator tokenholders, %s", k), nil
+				return nil, base.NewBaseOperationProcessReasonError("failed to find operator tokenholders, %s: %w", k, err), nil
 			case found:
 				hds, err = StateOperatorTokenHoldersValue(st)
 				if err != nil {
-					return nil, base.NewBaseOperationProcessReasonError("failed to get operator tokenholders, %s", k), nil
+					return nil, base.NewBaseOperationProcessReasonError("failed to get operator tokenholders, %s: %w", k, err), nil
 				}
 			default:
 				hds = []base.Address{}
@@ -246,11 +246,11 @@ func (opp *AuthorizeOperatorsProcessor) Process( // nolint:dupl
 		if _, found := operators[k]; !found {
 			switch st, found, err := getStateFunc(k); {
 			case err != nil:
-				return nil, base.NewBaseOperationProcessReasonError("failed to find tokenholder partition operators, %s", k), nil
+				return nil, base.NewBaseOperationProcessReasonError("failed to find tokenholder partition operators, %s: %w", k, err), nil
 			case found:
 				ops, err = StateTokenHolderPartitionOperatorsValue(st)
 				if err != nil {
-					return nil, base.NewBaseOperationProcessReasonError("failed to get tokenholder partition operators, %s", k), nil
+					return nil, base.NewBaseOperationProcessReasonError("failed to get tokenholder partition operators, %s: %w", k, err), nil
 				}
 			default:
 				ops = []base.Address{}
@@ -262,11 +262,11 @@ func (opp *AuthorizeOperatorsProcessor) Process( // nolint:dupl
 		if _, found := holders[k]; !found {
 			switch st, found, err := getStateFunc(k); {
 			case err != nil:
-				return nil, base.NewBaseOperationProcessReasonError("failed to find operator tokenholders, %s", k), nil
+				return nil, base.NewBaseOperationProcessReasonError("failed to find operator tokenholders, %s: %w", k, err), nil
 			case found:
 				hds, err = StateOperatorTokenHoldersValue(st)
 				if err != nil {
-					return nil, base.NewBaseOperationProcessReasonError("failed to get operator tokenholders, %s", k), nil
+					return nil, base.NewBaseOperationProcessReasonError("failed to get operator tokenholders, %s: %w", k, err), nil
 				}
 			default:
 				hds = []base.Address{}

--- a/sto/create_security_tokens_process.go
+++ b/sto/create_security_tokens_process.go
@@ -76,11 +76,8 @@ func (ipp *CreateSecurityTokensItemProcessor) Process(
 	documents := []Document{}
 
 	policy := NewSTOPolicy(partitions, currency.NewBig(0), it.Controllers(), documents)
-	if err := policy.IsValid(nil); err != nil {
-		return nil, err
-	}
-
 	design := NewSTODesign(it.STO(), it.Granularity(), policy)
+
 	if err := design.IsValid(nil); err != nil {
 		return nil, err
 	}

--- a/sto/create_security_tokens_process.go
+++ b/sto/create_security_tokens_process.go
@@ -154,7 +154,7 @@ func (opp *CreateSecurityTokensProcessor) PreProcess(
 	}
 
 	if err := checkNotExistsState(extensioncurrency.StateKeyContractAccount(fact.Sender()), getStateFunc); err != nil {
-		return ctx, base.NewBaseOperationProcessReasonError("contract account cannot create security tokens, %q", fact.Sender()), nil
+		return ctx, base.NewBaseOperationProcessReasonError("contract account cannot create security tokens, %q: %w", fact.Sender(), err), nil
 	}
 
 	if err := checkFactSignsByState(fact.sender, op.Signs(), getStateFunc); err != nil {

--- a/sto/issue_security_tokens_process.go
+++ b/sto/issue_security_tokens_process.go
@@ -263,7 +263,7 @@ func (opp *IssueSecurityTokensProcessor) PreProcess(
 	}
 
 	if err := checkNotExistsState(extensioncurrency.StateKeyContractAccount(fact.Sender()), getStateFunc); err != nil {
-		return ctx, base.NewBaseOperationProcessReasonError("contract account cannot issue security tokens, %q", fact.Sender()), nil
+		return ctx, base.NewBaseOperationProcessReasonError("contract account cannot issue security tokens, %q: %w", fact.Sender(), err), nil
 	}
 
 	if err := checkFactSignsByState(fact.sender, op.Signs(), getStateFunc); err != nil {

--- a/sto/redeem_tokens_process.go
+++ b/sto/redeem_tokens_process.go
@@ -316,7 +316,7 @@ func (opp *RedeemTokensProcessor) PreProcess(
 	}
 
 	if err := checkNotExistsState(extensioncurrency.StateKeyContractAccount(fact.Sender()), getStateFunc); err != nil {
-		return ctx, base.NewBaseOperationProcessReasonError("contract account cannot issue security tokens, %q", fact.Sender()), nil
+		return ctx, base.NewBaseOperationProcessReasonError("contract account cannot issue security tokens, %q: %w", fact.Sender(), err), nil
 	}
 
 	if err := checkFactSignsByState(fact.sender, op.Signs(), getStateFunc); err != nil {
@@ -331,12 +331,12 @@ func (opp *RedeemTokensProcessor) PreProcess(
 		if _, found := stos[k]; !found {
 			st, err := existsState(k, "key of sto design", getStateFunc)
 			if err != nil {
-				return nil, base.NewBaseOperationProcessReasonError("sto design doesn't exist, %q", k), nil
+				return nil, base.NewBaseOperationProcessReasonError("sto design doesn't exist, %q: %w", k, err), nil
 			}
 
 			design, err := StateSTODesignValue(st)
 			if err != nil {
-				return nil, base.NewBaseOperationProcessReasonError("failed to get sto design value, %q", k), nil
+				return nil, base.NewBaseOperationProcessReasonError("failed to get sto design value, %q: %w", k, err), nil
 			}
 
 			stos[k] = &design
@@ -390,12 +390,12 @@ func (opp *RedeemTokensProcessor) Process( // nolint:dupl
 		if _, found := stos[k]; !found {
 			st, err := existsState(k, "key of sto design", getStateFunc)
 			if err != nil {
-				return nil, base.NewBaseOperationProcessReasonError("sto design doesn't exist, %q", k), nil
+				return nil, base.NewBaseOperationProcessReasonError("sto design doesn't exist, %q: %w", k, err), nil
 			}
 
 			design, err := StateSTODesignValue(st)
 			if err != nil {
-				return nil, base.NewBaseOperationProcessReasonError("failed to get sto design value, %q", k), nil
+				return nil, base.NewBaseOperationProcessReasonError("failed to get sto design value, %q: %w", k, err), nil
 			}
 
 			stos[k] = &design

--- a/sto/revoke_operators_process.go
+++ b/sto/revoke_operators_process.go
@@ -187,7 +187,7 @@ func (opp *RevokeOperatorsProcessor) PreProcess(
 	}
 
 	if err := checkNotExistsState(extensioncurrency.StateKeyContractAccount(fact.Sender()), getStateFunc); err != nil {
-		return ctx, base.NewBaseOperationProcessReasonError("contract account cannot set its operators, %q", fact.Sender()), nil
+		return ctx, base.NewBaseOperationProcessReasonError("contract account cannot set its operators, %q: %w", fact.Sender(), err), nil
 	}
 
 	if err := checkFactSignsByState(fact.sender, op.Signs(), getStateFunc); err != nil {
@@ -204,11 +204,11 @@ func (opp *RevokeOperatorsProcessor) PreProcess(
 		if _, found := operators[k]; !found {
 			switch st, found, err := getStateFunc(k); {
 			case err != nil:
-				return nil, base.NewBaseOperationProcessReasonError("failed to find tokenholder partition operators, %s", k), nil
+				return nil, base.NewBaseOperationProcessReasonError("failed to find tokenholder partition operators, %s: %w", k, err), nil
 			case found:
 				ops, err = StateTokenHolderPartitionOperatorsValue(st)
 				if err != nil {
-					return nil, base.NewBaseOperationProcessReasonError("failed to get tokenholder partition operators, %s", k), nil
+					return nil, base.NewBaseOperationProcessReasonError("failed to get tokenholder partition operators, %s: %w", k, err), nil
 				}
 			default:
 				return nil, base.NewBaseOperationProcessReasonError("tokenholder partition operators not in state, %q", k), nil
@@ -220,11 +220,11 @@ func (opp *RevokeOperatorsProcessor) PreProcess(
 		if _, found := holders[k]; !found {
 			switch st, found, err := getStateFunc(k); {
 			case err != nil:
-				return nil, base.NewBaseOperationProcessReasonError("failed to find operator tokenholders, %s", k), nil
+				return nil, base.NewBaseOperationProcessReasonError("failed to find operator tokenholders, %s: %w", k, err), nil
 			case found:
 				hds, err = StateOperatorTokenHoldersValue(st)
 				if err != nil {
-					return nil, base.NewBaseOperationProcessReasonError("failed to get operator tokenholders, %s", k), nil
+					return nil, base.NewBaseOperationProcessReasonError("failed to get operator tokenholders, %s: %w", k, err), nil
 				}
 			default:
 				return nil, base.NewBaseOperationProcessReasonError("operator tokenholders not in state, %q", k), nil
@@ -279,11 +279,11 @@ func (opp *RevokeOperatorsProcessor) Process( // nolint:dupl
 		if _, found := operators[k]; !found {
 			switch st, found, err := getStateFunc(k); {
 			case err != nil:
-				return nil, base.NewBaseOperationProcessReasonError("failed to find tokenholder partition operators, %s", k), nil
+				return nil, base.NewBaseOperationProcessReasonError("failed to find tokenholder partition operators, %s: %w", k, err), nil
 			case found:
 				ops, err = StateTokenHolderPartitionOperatorsValue(st)
 				if err != nil {
-					return nil, base.NewBaseOperationProcessReasonError("failed to get tokenholder partition operators, %s", k), nil
+					return nil, base.NewBaseOperationProcessReasonError("failed to get tokenholder partition operators, %s: %w", k, err), nil
 				}
 			default:
 				return nil, base.NewBaseOperationProcessReasonError("tokenholder partition operators not in state, %q", k), nil
@@ -295,11 +295,11 @@ func (opp *RevokeOperatorsProcessor) Process( // nolint:dupl
 		if _, found := holders[k]; !found {
 			switch st, found, err := getStateFunc(k); {
 			case err != nil:
-				return nil, base.NewBaseOperationProcessReasonError("failed to find operator tokenholders, %s", k), nil
+				return nil, base.NewBaseOperationProcessReasonError("failed to find operator tokenholders, %s: %w", k, err), nil
 			case found:
 				hds, err = StateOperatorTokenHoldersValue(st)
 				if err != nil {
-					return nil, base.NewBaseOperationProcessReasonError("failed to get operator tokenholders, %s", k), nil
+					return nil, base.NewBaseOperationProcessReasonError("failed to get operator tokenholders, %s: %w", k, err), nil
 				}
 			default:
 				return nil, base.NewBaseOperationProcessReasonError("operator tokenholders not in state, %q", k), nil

--- a/sto/state.go
+++ b/sto/state.go
@@ -461,7 +461,7 @@ type OperatorTokenHoldersStateValue struct {
 
 func NewOperatorTokenHoldersStateValue(tokenHolders []base.Address) OperatorTokenHoldersStateValue {
 	return OperatorTokenHoldersStateValue{
-		BaseHinter:   hint.NewBaseHinter(TokenHolderPartitionOperatorsStateValueHint),
+		BaseHinter:   hint.NewBaseHinter(OperatorTokenHoldersStateValueHint),
 		TokenHolders: tokenHolders,
 	}
 }
@@ -473,7 +473,7 @@ func (o OperatorTokenHoldersStateValue) Hint() hint.Hint {
 func (o OperatorTokenHoldersStateValue) IsValid([]byte) error {
 	e := util.ErrInvalid.Errorf("invalid OperatorTokenHoldersStateValue")
 
-	if err := o.BaseHinter.IsValid(TokenHolderPartitionOperatorsStateValueHint.Type().Bytes()); err != nil {
+	if err := o.BaseHinter.IsValid(OperatorTokenHoldersStateValueHint.Type().Bytes()); err != nil {
 		return e.Wrap(err)
 	}
 

--- a/sto/state_json.go
+++ b/sto/state_json.go
@@ -36,7 +36,7 @@ func (de *STODesignStateValue) DecodeJSON(b []byte, enc *jsonenc.Encoder) error 
 
 	var design STODesign
 
-	if err := de.DecodeJSON(u.STO, enc); err != nil {
+	if err := design.DecodeJSON(u.STO, enc); err != nil {
 		return e(err, "")
 	}
 

--- a/sto/sto_design_encode.go
+++ b/sto/sto_design_encode.go
@@ -17,7 +17,7 @@ func (de *STODesign) unpack(enc encoder.Encoder, ht hint.Hint, sto string, gra u
 	if hinter, err := enc.Decode(bpo); err != nil {
 		return e(err, "")
 	} else if po, ok := hinter.(STOPolicy); !ok {
-		return util.ErrWrongType.Errorf("expected STOPolicy, not %T", hinter)
+		return e(util.ErrWrongType.Errorf("expected STOPolicy, not %T", hinter), "")
 	} else {
 		de.policy = po
 	}

--- a/sto/sto_policy.go
+++ b/sto/sto_policy.go
@@ -52,10 +52,6 @@ func (po STOPolicy) IsValid([]byte) error {
 		return util.ErrInvalid.Errorf("empty partitions")
 	}
 
-	if !po.aggregate.OverZero() {
-		return util.ErrInvalid.Errorf("aggregate must be over zero")
-	}
-
 	if err := util.CheckIsValiders(nil, false, po.BaseHinter); err != nil {
 		return util.ErrInvalid.Errorf("invalid currency policy: %w", err)
 	}

--- a/sto/sto_policy_encode.go
+++ b/sto/sto_policy_encode.go
@@ -44,7 +44,7 @@ func (po *STOPolicy) unpack(enc encoder.Encoder, ht hint.Hint, ps []string, big 
 	for i := range hds {
 		doc, ok := hds[i].(Document)
 		if !ok {
-			return util.ErrWrongType.Errorf("expected Document, not %T", hds[i])
+			return e(util.ErrWrongType.Errorf("expected Document, not %T", hds[i]), "")
 		}
 
 		documents[i] = doc

--- a/sto/transfer_security_tokens_partition_item_encode.go
+++ b/sto/transfer_security_tokens_partition_item_encode.go
@@ -40,7 +40,7 @@ func (it *TransferSecurityTokensPartitionItem) unpack(enc encoder.Encoder, ht hi
 
 	amount, err := currency.NewBigFromString(am)
 	if err != nil {
-		return err
+		return e(err, "")
 	}
 	it.amount = amount
 

--- a/sto/transfer_security_tokens_partition_process.go
+++ b/sto/transfer_security_tokens_partition_process.go
@@ -292,7 +292,7 @@ func (opp *TransferSecurityTokensPartitionProcessor) PreProcess(
 	}
 
 	if err := checkNotExistsState(extensioncurrency.StateKeyContractAccount(fact.Sender()), getStateFunc); err != nil {
-		return ctx, base.NewBaseOperationProcessReasonError("contract account cannot issue security tokens, %q", fact.Sender()), nil
+		return ctx, base.NewBaseOperationProcessReasonError("contract account cannot issue security tokens, %q: %w", fact.Sender(), err), nil
 	}
 
 	if err := checkFactSignsByState(fact.sender, op.Signs(), getStateFunc); err != nil {


### PR DESCRIPTION
### Pull-request Type (fix, feat, bug, doc, chore, test, etc...) 

- fix

### Current Behavior (Link to an open issue)

- Close #51
- Close #52
- Close #54

### New Behavior (if this is a feature change)

- add .gitignore
- make all errors in processors wrapped
- modify cmds/hinters.go
- modify some operation processors, decoders
- modify state.go because of OperatorTokenHoldersValue hint

### Other Information

- completion of the 1st test
